### PR TITLE
Update GitLab constructor

### DIFF
--- a/mrchecker/Jenkinsfile
+++ b/mrchecker/Jenkinsfile
@@ -3,7 +3,7 @@
 import com.capgemini.productionline.configuration.*
 
 Jenkins jenkinsConfiguration = new Jenkins();
-GitLab gitlabConfiguration = new GitLab(this, params.GITLAB_USER_PRIVATE_TOKEN)
+GitLab gitlabConfiguration = new GitLab(this, params.GITLAB_USER_PRIVATE_TOKEN, ProductionLineGlobals.GITLAB_BASE_URL);
 
 pipeline{
 


### PR DESCRIPTION
org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: No such constructor found: new com.capgemini.productionline.configuration.GitLab WorkflowScript java.lang.String
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onNewInstance(SandboxInterceptor.java:168)

after changed Gitlab constructor everything is working fine.